### PR TITLE
Add list and custom type support in the style of ppx_mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ extension will error if syntax checking fails. If this gives a false positive er
 
 
 ## Requirements
-The runtime requirements of Rapper are core, lwt, caqti, caqti-lwt and caqti-driver-postgresql. Only a very small amount of code from core is used though; if you would like to use Rapper without core please let me know.
+The runtime requirements of Rapper are base, lwt, caqti, caqti-lwt and caqti-driver-postgresql.
 
 ## Contributions
 Any contributions would be very welcome!

--- a/dune-project
+++ b/dune-project
@@ -1,19 +1,30 @@
 (lang dune 2.0.1)
+
 (name ppx_rapper)
+
 (version 0.9.3)
-(source (github roddyyaga/ppx_rapper))
+
+(source
+ (github roddyyaga/ppx_rapper))
+
 (documentation "https://github.com/roddyyaga/ppx_rapper")
+
 (license MIT)
+
 (authors "Roddy MacSween <github@roddymacsween.co.uk>")
+
 (maintainers "Roddy MacSween <github@roddymacsween.co.uk>")
+
 (generate_opam_files true)
+
 (package
-(name ppx_rapper)
-(synopsis "Syntax extension for Caqti/PostgreSQL queries")
-(depends
-(ocaml (>= 4.07))
-dune
-pg_query
-ppxlib
-)
-)
+ (name ppx_rapper)
+ (synopsis "Syntax extension for Caqti/PostgreSQL queries")
+ (depends
+  (ocaml
+   (>= 4.07))
+  dune
+  pg_query
+  ppxlib
+  base
+  caqti))

--- a/lib-runtime/dune
+++ b/lib-runtime/dune
@@ -1,0 +1,4 @@
+(library
+ (name ppx_rapper_runtime)
+ (public_name ppx_rapper.runtime)
+ (libraries caqti))

--- a/lib-runtime/ppx_rapper_runtime.ml
+++ b/lib-runtime/ppx_rapper_runtime.ml
@@ -1,0 +1,9 @@
+
+module Dynparam = struct
+  type t = Pack : 'a Caqti_type.t * 'a -> t
+
+  let empty = Pack (Caqti_type.unit, ())
+
+  let add t x (Pack (t', x')) = Pack (Caqti_type.tup2 t' t, (x', x))
+end
+

--- a/lib-runtime/ppx_rapper_runtime.ml
+++ b/lib-runtime/ppx_rapper_runtime.ml
@@ -1,3 +1,8 @@
+module type CUSTOM = sig
+  type t
+
+  val t : t Caqti_type.t
+end
 
 module Dynparam = struct
   type t = Pack : 'a Caqti_type.t * 'a -> t

--- a/lib-runtime/ppx_rapper_runtime.mli
+++ b/lib-runtime/ppx_rapper_runtime.mli
@@ -1,0 +1,8 @@
+module Dynparam : sig
+  type t = Pack : 'a Caqti_type.t * 'a -> t
+
+  val empty : t
+
+  val add : 'a Caqti_type.t -> 'a -> t -> t
+end
+

--- a/lib-runtime/ppx_rapper_runtime.mli
+++ b/lib-runtime/ppx_rapper_runtime.mli
@@ -1,3 +1,9 @@
+module type CUSTOM = sig
+  type t
+
+  val t : t Caqti_type.t
+end
+
 module Dynparam : sig
   type t = Pack : 'a Caqti_type.t * 'a -> t
 

--- a/ppx/codegen.ml
+++ b/ppx/codegen.ml
@@ -15,16 +15,26 @@ exception Error of string
 let up_to_last xs = List.take xs (List.length xs - 1)
 
 (** Produces individual Caqti types from parsed parameters *)
-let caqti_type_of_param ~loc Query.{ typ = _, base_type; opt; _ } =
+let caqti_type_of_param ~loc Query.{ typ; opt; _ } =
   let base_expr =
-    match base_type with
-    | "string" -> [%expr string]
-    | "int" -> [%expr int]
-    | "bool" -> [%expr bool]
-    | "float" -> [%expr float]
-    (* TODO - support custom types *)
-    | other ->
-        raise (Error (Printf.sprintf "Base type '%s' not supported" other))
+    match typ with
+    | None, base_type ->
+      begin match base_type with
+      | "string" -> [%expr string]
+      | "octets" -> [%expr octets]
+      | "int" -> [%expr int]
+      | "int32" -> [%expr int32]
+      | "int64" -> [%expr int64]
+      | "bool" -> [%expr bool]
+      | "float" -> [%expr float]
+      | "pdate" -> [%expr pdate]
+      | "ptime" -> [%expr ptime]
+      | "ptime_span" -> [%expr ptime_span]
+      | other ->
+          raise (Error (Printf.sprintf "Base type '%s' not supported" other))
+      end
+    | Some module_name, typ ->
+      Buildef.pexp_ident ~loc (Loc.make ~loc (Ldot (Lident module_name, typ)))
   in
   match opt with
   | true -> Buildef.(pexp_apply ~loc [%expr option] [ (Nolabel, base_expr) ])

--- a/ppx/dune
+++ b/ppx/dune
@@ -4,5 +4,5 @@
 (name ppx_rapper)
 (public_name ppx_rapper)
 (kind ppx_rewriter)
-(libraries core ppxlib pg_query)
+(libraries ppxlib pg_query base)
 (preprocess (pps ppxlib.metaquot)))

--- a/ppx/ppx_rapper.ml
+++ b/ppx/ppx_rapper.ml
@@ -99,8 +99,8 @@ let make_expand_get_and_exec_expression ~loc parsed_query record_in record_out =
              [%expr
                Caqti_request.([%e caqti_request_function_expr])
                ~oneshot:true
-               [%e caqti_input_type]
-               Caqti_type.([%e outputs_caqti_type])
+               ([%e caqti_input_type] [@ocaml.warning "-33"])
+               (Caqti_type.([%e outputs_caqti_type]) [@ocaml.warning "-33"])
                sql ])
       with Codegen.Error s -> Error s
     in
@@ -142,8 +142,8 @@ let make_expand_get_and_exec_expression ~loc parsed_query record_in record_out =
         Ok (make_generic make_function
             [%expr
               Caqti_request.([%e caqti_request_function_expr])
-                Caqti_type.([%e inputs_caqti_type])
-                Caqti_type.([%e outputs_caqti_type])
+                (Caqti_type.([%e inputs_caqti_type]) [@ocaml.warning "-33"])
+                (Caqti_type.([%e outputs_caqti_type]) [@ocaml.warning "-33"])
                 [%e parsed_sql]])
       with Codegen.Error s -> Error s
     in
@@ -153,7 +153,7 @@ let make_expand_get_and_exec_expression ~loc parsed_query record_in record_out =
         Ok (make_generic make_function
             [%expr
               Caqti_request.([%e caqti_request_function_expr])
-                Caqti_type.([%e inputs_caqti_type])
+                (Caqti_type.([%e inputs_caqti_type]) [@ocaml.warning "-33"])
                 [%e parsed_sql]])
       with Codegen.Error s -> Error s
     in

--- a/ppx/ppx_rapper.ml
+++ b/ppx/ppx_rapper.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Ppxlib
 module Buildef = Ast_builder.Default
 

--- a/ppx/query.mli
+++ b/ppx/query.mli
@@ -6,8 +6,6 @@ type param = {
   typ : string option * string;
   opt : bool;
   name : string;
-  of_string : string * string;
-  to_string : string * string
 }
 
 type list_params = {

--- a/ppx/query.mll
+++ b/ppx/query.mll
@@ -19,8 +19,7 @@ type param =
   { typ : string option * string
   ; opt : bool
   ; name : string
-  ; of_string : string * string
-  ; to_string : string * string }
+  }
 
 type list_params =
   { subsql : string
@@ -62,22 +61,31 @@ let build_param spec opt name =
   let open Result in
   begin match spec with
   | "int" ->
-      Ok ((None, "int"), ("Ppx_mysql_runtime", "int_of_string"), ("Stdlib", "string_of_int"))
+      Ok (None, "int")
   | "int32" ->
-      Ok ((None, "int32"), ("Ppx_mysql_runtime", "int32_of_string"), ("Int32", "to_string"))
+      Ok (None, "int32")
   | "int64" ->
-      Ok ((None, "int64"), ("Ppx_mysql_runtime", "int64_of_string"), ("Int64", "to_string"))
+      Ok (None, "int64")
   | "bool" ->
-      Ok ((None, "bool"), ("Ppx_mysql_runtime", "bool_of_string"), ("Stdlib", "string_of_bool"))
+      Ok (None, "bool")
   | "string" ->
-      Ok ((None, "string"), ("Ppx_mysql_runtime", "string_of_string"), ("Ppx_mysql_runtime", "identity"))
-  | "float" -> Ok ((None, "float"), ("this", "is"), ("not", "used"))
+      Ok (None, "string")
+  | "octets" ->
+      Ok (None, "octets")
+  | "pdate" ->
+      Ok (None, "pdate")
+  | "ptime" ->
+      Ok (None, "ptime")
+  | "ptime_span" ->
+      Ok (None, "ptime_span")
+  | "float" ->
+      Ok (None, "float")
   | module_name when String.length module_name > 0 && module_name.[0] >= 'A' && module_name.[0] <= 'Z' ->
-      Ok ((Some module_name, "t"), (module_name, "of_mysql"), (module_name, "to_mysql"))
+      Ok (Some module_name, "t")
   | spec ->
       Error (`Unknown_type_spec spec)
-  end >>= fun (typ, of_string, to_string) ->
-  Ok {typ; opt = (opt = "?"); name; of_string; to_string}
+  end >>= fun typ ->
+  Ok {typ; opt = (opt = "?"); name}
 }
 
 let escape = '\\'

--- a/ppx_rapper.opam
+++ b/ppx_rapper.opam
@@ -13,6 +13,8 @@ depends: [
   "dune"
   "pg_query"
   "ppxlib"
+  "base"
+  "caqti"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/test/rewriter/test.expected.ml
+++ b/test/rewriter/test.expected.ml
@@ -296,3 +296,31 @@ let get_cards =
       match result with | Ok x -> Ok (f x) | Error e -> Error e in
     Lwt.map f (Db.collect_list query suit) in
   wrapped
+let all_types =
+  let query =
+    (let open Caqti_request in collect) ((let open Caqti_type in unit)
+      [@ocaml.warning "-33"])
+      ((let open Caqti_type in
+          tup2 string
+            (tup2 octets
+               (tup2 int
+                  (tup2 int32
+                     (tup2 int64
+                        (tup2 bool
+                           (tup2 float (tup2 pdate (tup2 ptime ptime_span)))))))))
+      [@ocaml.warning "-33"])
+      " SELECT id, payload, version,\n                some_int32, some_int64, added,\n                fl, date, time, span\n         FROM some_table " in
+  let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) () =
+    let f result =
+      let g
+        (id,
+         (payload,
+          (version,
+           (some_int32, (some_int64, (added, (fl, (date, (time, span)))))))))
+        =
+        (id, payload, version, some_int32, some_int64, added, fl, date, time,
+          span) in
+      let f = List.map g in
+      match result with | Ok x -> Ok (f x) | Error e -> Error e in
+    Lwt.map f (Db.collect_list query ()) in
+  wrapped

--- a/test/rewriter/test.expected.ml
+++ b/test/rewriter/test.expected.ml
@@ -11,31 +11,36 @@ type c = {
 let many_arg_execute =
   let query =
     (let open Caqti_request in exec)
-      (let open Caqti_type in
-         tup2 string (tup2 string (tup2 (option string) int)))
+      ((let open Caqti_type in
+          tup2 string (tup2 string (tup2 (option string) int)))
+      [@ocaml.warning "-33"])
       "\n      UPDATE users\n      SET (username, email, bio) = (?, ?, ?)\n      WHERE id = ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username 
     ~email  ~bio  ~id  = Db.exec query (username, (email, (bio, id))) in
   wrapped
 let single_arg_execute =
   let query =
-    (let open Caqti_request in exec) (let open Caqti_type in string)
+    (let open Caqti_request in exec) ((let open Caqti_type in string)
+      [@ocaml.warning "-33"])
       "\n      UPDATE users\n      SET username = ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username  =
     Db.exec query username in
   wrapped
 let no_arg_execute =
   let query =
-    (let open Caqti_request in exec) (let open Caqti_type in unit)
+    (let open Caqti_request in exec) ((let open Caqti_type in unit)
+      [@ocaml.warning "-33"])
       "\n      UPDATE users\n      SET username = 'Hello!'\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) () =
     Db.exec query () in
   wrapped
 let many_arg_get_one =
   let query =
-    (let open Caqti_request in find) (let open Caqti_type in tup2 string int)
-      (let open Caqti_type in
-         tup2 int (tup2 string (tup2 (option string) bool)))
+    (let open Caqti_request in find)
+      ((let open Caqti_type in tup2 string int)[@ocaml.warning "-33"])
+      ((let open Caqti_type in
+          tup2 int (tup2 string (tup2 (option string) bool)))
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username, bio, is_married\n      FROM users\n      WHERE username = ? AND id > ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username 
     ~min_id  =
@@ -48,8 +53,9 @@ let many_arg_get_one =
   wrapped
 let single_arg_get_one =
   let query =
-    (let open Caqti_request in find) (let open Caqti_type in string)
-      (let open Caqti_type in tup2 int string)
+    (let open Caqti_request in find) ((let open Caqti_type in string)
+      [@ocaml.warning "-33"]) ((let open Caqti_type in tup2 int string)
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      WHERE username = ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username  =
     let f result =
@@ -60,8 +66,10 @@ let single_arg_get_one =
   wrapped
 let no_arg_get_one =
   let query =
-    (let open Caqti_request in find) (let open Caqti_type in unit)
-      (let open Caqti_type in tup2 int (tup2 string string))
+    (let open Caqti_request in find) ((let open Caqti_type in unit)
+      [@ocaml.warning "-33"])
+      ((let open Caqti_type in tup2 int (tup2 string string))
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username, email\n      FROM users\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) () =
     let f result =
@@ -73,8 +81,9 @@ let no_arg_get_one =
 let many_arg_get_one_repeated_arg =
   let query =
     (let open Caqti_request in find)
-      (let open Caqti_type in tup2 int (tup2 string int))
-      (let open Caqti_type in string)
+      ((let open Caqti_type in tup2 int (tup2 string int))
+      [@ocaml.warning "-33"]) ((let open Caqti_type in string)
+      [@ocaml.warning "-33"])
       "\n      SELECT username\n      FROM users\n      WHERE id = ? OR username = ? OR id <> ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~id  ~username 
     =
@@ -85,8 +94,8 @@ let many_arg_get_one_repeated_arg =
 let many_arg_get_opt =
   let query =
     (let open Caqti_request in find_opt)
-      (let open Caqti_type in tup2 string int)
-      (let open Caqti_type in tup2 int string)
+      ((let open Caqti_type in tup2 string int)[@ocaml.warning "-33"])
+      ((let open Caqti_type in tup2 int string)[@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      WHERE username = ? AND id > ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username 
     ~min_id  =
@@ -100,8 +109,9 @@ let many_arg_get_opt =
   wrapped
 let single_arg_get_opt =
   let query =
-    (let open Caqti_request in find_opt) (let open Caqti_type in string)
-      (let open Caqti_type in tup2 int string)
+    (let open Caqti_request in find_opt) ((let open Caqti_type in string)
+      [@ocaml.warning "-33"]) ((let open Caqti_type in tup2 int string)
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      WHERE username = ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username  =
     let f result =
@@ -114,8 +124,9 @@ let single_arg_get_opt =
   wrapped
 let no_arg_get_opt =
   let query =
-    (let open Caqti_request in find_opt) (let open Caqti_type in unit)
-      (let open Caqti_type in tup2 int string)
+    (let open Caqti_request in find_opt) ((let open Caqti_type in unit)
+      [@ocaml.warning "-33"]) ((let open Caqti_type in tup2 int string)
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) () =
     let f result =
@@ -129,8 +140,8 @@ let no_arg_get_opt =
 let many_arg_get_many =
   let query =
     (let open Caqti_request in collect)
-      (let open Caqti_type in tup2 string int)
-      (let open Caqti_type in tup2 int string)
+      ((let open Caqti_type in tup2 string int)[@ocaml.warning "-33"])
+      ((let open Caqti_type in tup2 int string)[@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      WHERE username = ? AND id > ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username 
     ~min_id  =
@@ -142,8 +153,9 @@ let many_arg_get_many =
   wrapped
 let single_arg_get_many =
   let query =
-    (let open Caqti_request in collect) (let open Caqti_type in string)
-      (let open Caqti_type in tup2 int string)
+    (let open Caqti_request in collect) ((let open Caqti_type in string)
+      [@ocaml.warning "-33"]) ((let open Caqti_type in tup2 int string)
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      WHERE username = ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~username  =
     let f result =
@@ -154,8 +166,9 @@ let single_arg_get_many =
   wrapped
 let no_arg_get_many =
   let query =
-    (let open Caqti_request in collect) (let open Caqti_type in unit)
-      (let open Caqti_type in tup2 int string)
+    (let open Caqti_request in collect) ((let open Caqti_type in unit)
+      [@ocaml.warning "-33"]) ((let open Caqti_type in tup2 int string)
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username\n      FROM users\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) () =
     let f result =
@@ -167,9 +180,10 @@ let no_arg_get_many =
 let my_query =
   let query =
     (let open Caqti_request in find_opt)
-      (let open Caqti_type in tup2 string int)
-      (let open Caqti_type in
-         tup2 int (tup2 string (tup2 bool (option string))))
+      ((let open Caqti_type in tup2 string int)[@ocaml.warning "-33"])
+      ((let open Caqti_type in
+          tup2 int (tup2 string (tup2 bool (option string))))
+      [@ocaml.warning "-33"])
       "\n      SELECT id, username, following, bio\n      FROM users\n      WHERE username <> ? AND id > ?\n      " in
   let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~wrong_user 
     ~min_id  =
@@ -207,8 +221,9 @@ let list =
           let query =
             (let open Caqti_request in find_opt) ~oneshot:true
               (let open Caqti_type in tup2 bool packed_list_type)
-              (let open Caqti_type in
-                 tup2 int (tup2 string (tup2 bool (option string)))) sql in
+              ((let open Caqti_type in
+                  tup2 int (tup2 string (tup2 bool (option string))))
+              [@ocaml.warning "-33"]) sql in
           let f result =
             let g (id, (username, (following, bio))) =
               (id, username, following, bio) in
@@ -242,6 +257,42 @@ let collect_list =
               Dynparam.empty elems in
           let query =
             (let open Caqti_request in collect) ~oneshot:true
-              packed_list_type (let open Caqti_type in string) sql in
+              packed_list_type ((let open Caqti_type in string)
+              [@ocaml.warning "-33"]) sql in
           Db.collect_list query versions in
+  wrapped
+module Suit : Ppx_rapper_runtime.CUSTOM =
+  struct
+    type t =
+      | Clubs 
+      | Diamonds 
+      | Hearts 
+      | Spades 
+    let t =
+      let encode =
+        function
+        | Clubs -> Ok "c"
+        | Diamonds -> Ok "d"
+        | Hearts -> Ok "h"
+        | Spades -> Ok "s" in
+      let decode =
+        function
+        | "c" -> Ok Clubs
+        | "d" -> Ok Diamonds
+        | "h" -> Ok Hearts
+        | "s" -> Ok Spades
+        | _ -> Error "invalid suit" in
+      let open Caqti_type in custom ~encode ~decode string
+  end 
+let get_cards =
+  let query =
+    (let open Caqti_request in collect) ((let open Caqti_type in Suit.t)
+      [@ocaml.warning "-33"]) ((let open Caqti_type in tup2 int Suit.t)
+      [@ocaml.warning "-33"]) " SELECT id, suit FROM cards WHERE suit <> ? " in
+  let wrapped ((module Db)  : (module Caqti_lwt.CONNECTION)) ~suit  =
+    let f result =
+      let g (id, suit) = (id, suit) in
+      let f = List.map g in
+      match result with | Ok x -> Ok (f x) | Error e -> Error e in
+    Lwt.map f (Db.collect_list query suit) in
   wrapped

--- a/test/rewriter/test.ml
+++ b/test/rewriter/test.ml
@@ -145,3 +145,27 @@ let collect_list =
   [%rapper
     get_many
       {sql| SELECT @string{id} from schema_migrations where version in (%list{%int{versions}})|sql}]
+
+module Suit : Ppx_rapper_runtime.CUSTOM = struct
+  type t = Clubs | Diamonds | Hearts | Spades
+
+  let t =
+    let encode = function
+      | Clubs -> Ok "c"
+      | Diamonds -> Ok "d"
+      | Hearts -> Ok "h"
+      | Spades -> Ok "s"
+    in
+    let decode = function
+      | "c" -> Ok Clubs
+      | "d" -> Ok Diamonds
+      | "h" -> Ok Hearts
+      | "s" -> Ok Spades
+      | _   -> Error "invalid suit"
+    in
+    Caqti_type.(custom ~encode ~decode string)
+end
+
+let get_cards =
+  [%rapper get_many
+   {sql| SELECT @int{id}, @Suit{suit} FROM cards WHERE suit <> %Suit{suit} |sql}]

--- a/test/rewriter/test.ml
+++ b/test/rewriter/test.ml
@@ -138,5 +138,10 @@ let list =
       {sql|
       SELECT @int{id}, @string{username}, @bool{following}, @string?{bio}
       FROM users
-      WHERE following is %bool{following} and username IN (%list{%int{ids}})
-      |sql} syntax_off]
+      WHERE following = %bool{following} and username IN (%list{%int{ids}})
+      |sql}]
+
+let collect_list =
+  [%rapper
+    get_many
+      {sql| SELECT @string{id} from schema_migrations where version in (%list{%int{versions}})|sql}]

--- a/test/rewriter/test.ml
+++ b/test/rewriter/test.ml
@@ -131,3 +131,12 @@ let my_query =
       FROM users
       WHERE username <> %string{wrong_user} AND id > %int{min_id}
       |sql}]
+
+let list =
+  [%rapper
+    get_opt
+      {sql|
+      SELECT @int{id}, @string{username}, @bool{following}, @string?{bio}
+      FROM users
+      WHERE following is %bool{following} and username IN (%list{%int{ids}})
+      |sql} syntax_off]

--- a/test/rewriter/test.ml
+++ b/test/rewriter/test.ml
@@ -169,3 +169,12 @@ end
 let get_cards =
   [%rapper get_many
    {sql| SELECT @int{id}, @Suit{suit} FROM cards WHERE suit <> %Suit{suit} |sql}]
+
+let all_types =
+  [%rapper get_many
+   {sql| SELECT @string{id}, @octets{payload}, @int{version},
+                @int32{some_int32}, @int64{some_int64}, @bool{added},
+                @float{fl}, @pdate{date}, @ptime{time}, @ptime_span{span}
+         FROM some_table |sql}]
+
+


### PR DESCRIPTION
This diff does a few things:

1. ports from core to base which is much lighter weight 
2. Adds `list` support in the input parameters
3. As part of 2. a new sub-library is added which makes this PPX have a small runtime for dynamic parameters in the style of https://github.com/paurkedal/ocaml-caqti/issues/15#issuecomment-386793041

There are a couple things left to do here:

- add some form of documentation to the README that explains how to use list input parameters
- more general than this PR, but the lib would benefit from a refactoring pass, there's some things that are hard to work with.

Note: because queries containing list parameters are dynamically constructed, they need to be `~oneshot:true` as per Caqti's docs.