### PR TITLE
Add support for `let%rapper` pattern captures.

### DIFF
--- a/test/ppx/test.expected.ml
+++ b/test/ppx/test.expected.ml
@@ -400,3 +400,14 @@ let get_multiple_function_out loaders =
       match result with | Ok x -> Ok (f x) | Error e -> Error e in
     Rapper_helper.map f (Db.collect_list query ()) in
   wrapped loaders
+let use_let_syntax =
+  let query =
+    (let open Caqti_request in exec)
+      ((let open Caqti_type in
+          tup2 string (tup2 string (tup2 (option string) int)))
+      [@ocaml.warning "-33"])
+      "\n      UPDATE users\n      SET (username, email, bio) = (?, ?, ?)\n      WHERE id = ?\n      " in
+  let wrapped ~username  ~email  ~bio  ~id 
+    ((module Db)  : (module Rapper_helper.CONNECTION)) =
+    Db.exec query (username, (email, (bio, id))) in
+  wrapped

--- a/test/ppx/test.ml
+++ b/test/ppx/test.ml
@@ -223,3 +223,11 @@ let get_multiple_function_out =
       ORDER BY users.id
       |sql}
       function_out]
+
+let%rapper use_let_syntax =
+  execute
+    {sql|
+      UPDATE users
+      SET (username, email, bio) = (%string{username}, %string{email}, %string?{bio})
+      WHERE id = %int{id}
+      |sql}


### PR DESCRIPTION
Hi! First of all, thanks for a great ppx! :)

This is just a proposal to allow for an alternative way to write the ppx using `let` declarations. This is functionally identical to the current version but, in my opinion, looks a little bit less noisy and reduces code nesting.

Here's how the example from the README would looks like:

```ocaml
let%rapper my_query =
  get_opt {sql|
    SELECT @int{id}, @string{username}, @bool{following}, @string?{bio}
    FROM users
    WHERE username <> %string{wrong_user} AND id > %int{min_id}
  |sql}
```

<details><summary>Before</summary>

```ocaml
let my_query =
  [%rapper
    get_opt
      {sql|
      SELECT @int{id}, @string{username}, @bool{following}, @string?{bio}
      FROM users
      WHERE username <> %string{wrong_user} AND id > %int{min_id}
      |sql}]
```

</details>

I can update the README if you are happy with this change.