### PR TITLE
`function_out`: generate labelled params in the order they're queried

### DIFF
--- a/ppx/codegen.ml
+++ b/ppx/codegen.ml
@@ -178,7 +178,8 @@ let make_qualified_output out_params =
         in
         Hashtbl.set record_name_groups ~key ~data:(param :: current));
     let sorted_groups =
-      List.map !sorted_keys ~f:(Hashtbl.find_exn record_name_groups)
+      List.map !sorted_keys ~f:(fun k ->
+          Hashtbl.find_exn record_name_groups k |> List.rev)
     in
     Many sorted_groups
 
@@ -232,8 +233,7 @@ let function_body_general ~loc factory connection_function_expr
       in
       let function_expression ~loc n out_params =
         Buildef.(
-          pexp_apply ~loc (nth_loader ~loc n)
-            (arg_list_of_params (List.rev out_params)))
+          pexp_apply ~loc (nth_loader ~loc n) (arg_list_of_params out_params))
       in
 
       let output_nested_tuple_pattern, output_expression =


### PR DESCRIPTION
This is a quality of life improvement for e.g.:

```ocaml
[%rapper get_many {sql
  SELECT @string{x}, @string{y}, @string{z} FROM whatever
|sql} function_out]
```

Previously it'd generate a function with type `z: string -> y: string -> x: string`. It's nicer to generate `x: string -> y: string -> z: string`, as that's how I wrote them out in the SQL.

This was already correct for `One` case. The `Many` case is what needed fixing.