### PR TITLE
Update test for ppxlib.0.31.0

### DIFF
--- a/ppx_rapper.opam
+++ b/ppx_rapper.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "pg_query"
   "ppxlib" {>= "0.3.1"}
+  "ppxlib" {with-test & >= "0.31.1"}
   "base" {>= "v0.11.1"}
   "caqti" {>= "1.2.0"}
 ]

--- a/test/ppx/test.expected.ml
+++ b/test/ppx/test.expected.ml
@@ -220,7 +220,8 @@ let list =
                      [@ocaml.warning "-33"]) item pack) Dynparam.empty elems in
           let query =
             Caqti_request.Infix.(->?) ~oneshot:true
-              (let open Caqti_type in tup2 bool packed_list_type)
+              ((let open Caqti_type in tup2 bool packed_list_type)
+              [@ocaml.warning "-33"])
               ((let open Caqti_type in
                   tup2 int (tup2 string (tup2 bool (option string))))
               [@ocaml.warning "-33"]) sql in
@@ -256,8 +257,9 @@ let collect_list =
                    Dynparam.add ((let open Caqti_type in int)
                      [@ocaml.warning "-33"]) item pack) Dynparam.empty elems in
           let query =
-            Caqti_request.Infix.( ->* ) ~oneshot:true packed_list_type
-              ((let open Caqti_type in string)[@ocaml.warning "-33"]) sql in
+            Caqti_request.Infix.( ->* ) ~oneshot:true ((packed_list_type)
+              [@ocaml.warning "-33"]) ((let open Caqti_type in string)
+              [@ocaml.warning "-33"]) sql in
           Db.collect_list query versions in
   wrapped
 module Suit : Ppx_rapper_runtime.CUSTOM =


### PR DESCRIPTION
Ppxlib.0.31.0 fixes a bug in `metaquot` due to which attributes would be dropped sometimes. This PR updates the `ppx_rapper` test according to that bug fix and sets a ppxlib test bound accordingly. See https://github.com/ocaml/opam-repository/pull/24497#issuecomment-1739800622.